### PR TITLE
qsize is not reliable

### DIFF
--- a/tests/test_wasapi_client.py
+++ b/tests/test_wasapi_client.py
@@ -463,9 +463,7 @@ class TestDownloader:
         result_q = multiprocessing.Queue()
         log_q = multiprocessing.Queue()
         with patch('wasapi_client.verify_file', return_value=True):
-            p = wc.Downloader(get_q, result_q, log_q)
-            p.start()
-            p.join()
+            wc.Downloader(get_q, result_q, log_q).start()
         # If the join doesn't block, the queue is fully processed.
         get_q.join()
         assert result_q.qsize() == 2
@@ -483,9 +481,7 @@ class TestDownloader:
         result_q = multiprocessing.Queue()
         log_q = multiprocessing.Queue()
 
-        p = wc.Downloader(get_q, result_q, log_q)
-        p.start()
-        p.join()
+        wc.Downloader(get_q, result_q, log_q).start()
         # If the join doesn't block, the queue is fully processed.
         get_q.join()
         assert result_q.qsize() == 2

--- a/tests/test_wasapi_client.py
+++ b/tests/test_wasapi_client.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import multiprocessing
 from collections import OrderedDict
+from queue import Empty
 from unittest.mock import call, mock_open, patch
 
 import pytest
@@ -466,7 +467,9 @@ class TestDownloader:
             p = wc.Downloader(get_q, result_q, log_q)
             p.start()
             p.join()
-        assert get_q.qsize() == 0
+        # Check we have processed all of our GETs.
+        with pytest.raises(Empty):
+            get_q.get(block=False)
         assert result_q.qsize() == 2
         assert log_q.qsize() == 0
         for _ in (1, 2):
@@ -485,7 +488,9 @@ class TestDownloader:
         p = wc.Downloader(get_q, result_q, log_q)
         p.start()
         p.join()
-        assert get_q.qsize() == 0
+        # Check we have processed all of our GETs.
+        with pytest.raises(Empty):
+            get_q.get(block=False)
         assert result_q.qsize() == 2
         assert log_q.qsize() == 2
         for _ in (1, 2):

--- a/tests/test_wasapi_client.py
+++ b/tests/test_wasapi_client.py
@@ -4,7 +4,6 @@ import hashlib
 import json
 import multiprocessing
 from collections import OrderedDict
-from queue import Empty
 from unittest.mock import call, mock_open, patch
 
 import pytest
@@ -467,9 +466,8 @@ class TestDownloader:
             p = wc.Downloader(get_q, result_q, log_q)
             p.start()
             p.join()
-        # Check we have processed all of our GETs.
-        with pytest.raises(Empty):
-            get_q.get(block=False)
+        # If the join doesn't block, the queue is fully processed.
+        get_q.join()
         assert result_q.qsize() == 2
         assert log_q.qsize() == 0
         for _ in (1, 2):
@@ -488,9 +486,8 @@ class TestDownloader:
         p = wc.Downloader(get_q, result_q, log_q)
         p.start()
         p.join()
-        # Check we have processed all of our GETs.
-        with pytest.raises(Empty):
-            get_q.get(block=False)
+        # If the join doesn't block, the queue is fully processed.
+        get_q.join()
         assert result_q.qsize() == 2
         assert log_q.qsize() == 2
         for _ in (1, 2):


### PR DESCRIPTION
qsize is [not reliable](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Queue). I knew, that but it seemed to be working locally. :grin: @somexpert 