### PR TITLE
Use a configuration. Resolve #13.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Once installed, run the client at the commandline with:
 That gives you usage instructions:
 
 ```
-usage: wasapi-client [-h] [-b BASE_URI] [-d DESTINATION] [-l LOG] [-n]
-                     [-u USER] [-v] [-c | -m | -p PROCESSES | -s | -r]
+usage: wasapi-client [-h] [-b BASE_URI] [-d DESTINATION] [-l LOG] [-n] [-v]
+                     [--profile PROFILE] [-c | -m | -p PROCESSES | -s | -r]
                      [--collection COLLECTION [COLLECTION ...]]
                      [--filename FILENAME] [--crawl CRAWL]
                      [--crawl-time-after CRAWL_TIME_AFTER]
@@ -53,8 +53,8 @@ optional arguments:
   -l LOG, --log LOG     file to which logging should be written
   -n, --no-manifest     do not generate checksum files (ignored when used in
                         combination with --manifest)
-  -u USER, --user USER  username for API authentication
   -v, --verbose         log verbosely; -v is INFO, -vv is DEBUG
+  --profile PROFILE     profile to use
   -c, --count           print number of files for download and exit
   -m, --manifest        generate checksum files only and exit
   -p PROCESSES, --processes PROCESSES
@@ -80,9 +80,19 @@ query parameters:
                         date
 ```
 
+## Configuration
+
 When you are using the tool to query an Archive-It WASAPI endpoint,
-you will need to supply a username with `-u`, and you will be prompted
-for a password.
+you will need to supply a profile `--profile` from the configuration
+file. The configuration file should be at `~/.wasapi-client`.
+
+An example profile:
+
+```
+[unt]
+username = exampleUser
+password = examplePassword
+```
 
 ## Example Usage
 
@@ -91,7 +101,7 @@ with `crawl id` 256119 and logs program output to a file named
 `out.log`. Downloads are carried out by one process.
 
 ```
- $ wasapi-client -u user.name --crawl 256119 --log out.log -p 1
+ $ wasapi-client --profile unt --crawl 256119 --log out.log -p 1
 ```
 
 The following command downloads the WARC files available from crawls
@@ -100,7 +110,7 @@ written to a file named out.log. Downloads are happening via four
 processes and written to a directory at /tmp/wasapi_warcs/.
 
 ```
- $ wasapi-client -u user.name --crawl-start-after 2016-12-22T13:01:00 --crawl-start-before 2016-12-22T15:11:00  -vv --log out.log -p 4 -d /tmp/wasapi_warcs/
+ $ wasapi-client --profile unt --crawl-start-after 2016-12-22T13:01:00 --crawl-start-before 2016-12-22T15:11:00  -vv --log out.log -p 4 -d /tmp/wasapi_warcs/
 
 ```
 
@@ -108,21 +118,21 @@ The following command produces the size and file count of all content
 available to the user.
 
 ```
- $ wasapi-client -u user.name -s 
+ $ wasapi-client --profile unt -s 
 ```
 
 The following command gives the user the number of files available by
 the given query parameters.
 
 ```
- $ wasapi-client -u user.name --crawl 256119 -c 
+ $ wasapi-client --profile unt --crawl 256119 -c 
 ```
 
 The following command downloads the file called example.warc.gz to
 the current working directory.
 
 ```
-$ wasapi-client -u user.name --filename example.warc.gz
+$ wasapi-client --profile unt --filename example.warc.gz
 ```
 
 By default, manifest files are generated to provide checksums for the
@@ -132,14 +142,14 @@ download destination. If you don't want manifest files, use the --no-manifest
 flag.
 
 ```
-$ wasapi-client -u user.name --crawl 256119 --log out.log --no-manifest
+$ wasapi-client --profile unt --crawl 256119 --log out.log --no-manifest
 ```
 
 If you want to generate manifest files for your available webdata files
 without actually downloading the webdata files, use the --manifest flag.
 
 ```
-$ wasapi-client -u user.name --crawl 256119 --manifest
+$ wasapi-client --profile unt --crawl 256119 --manifest
 ```
 
 If you would like to produce a list of URLs where your webdata files can
@@ -147,7 +157,7 @@ later be downloaded by another tool (such as wget) rather than having
 wasapi-client do the downloading, use the --urls flag.
 
 ```
-$ wasapi-client -u user.name --crawl 256119 --urls
+$ wasapi-client --profile unt --crawl 256119 --urls
 ```
 
 ## Run the Tests


### PR DESCRIPTION
Tested out with a UofT collection from the WALK project, and it seems to be working just fine.

```
$ wasapi-client --profile uoft --collection 3552 --destination /tmp/test
```

```
$ ls -1 /tmp/test 
ARCHIVEIT-3552-DAILY-6726-20130215203958663-00000-wbgrp-crawl058.us.archive.org-6440.warc.gz
ARCHIVEIT-3552-DAILY-AOVPHD-20130210233602-00000-crawling113.us.archive.org-6682.warc.gz
ARCHIVEIT-3552-DAILY-CAWQOL-20130209233552-00000-wbgrp-crawl105.us.archive.org-6681.warc.gz
ARCHIVEIT-3552-DAILY-GVBXUZ-20130208234055-00000-wbgrp-crawl104.us.archive.org-6681.warc.gz
ARCHIVEIT-3552-DAILY-IEDLRH-20130211190052-00000-wbgrp-crawl052.us.archive.org-6680.warc.gz
ARCHIVEIT-3552-DAILY-IEDLRH-20130212071008-00001-wbgrp-crawl052.us.archive.org-6680.warc.gz
ARCHIVEIT-3552-DAILY-IEDLRH-20130212072904-00002-wbgrp-crawl052.us.archive.org-6680.warc.gz
ARCHIVEIT-3552-DAILY-IEDLRH-20130212110036-00003-wbgrp-crawl052.us.archive.org-6680.warc.gz
ARCHIVEIT-3552-DAILY-PQQPKT-20130208232734-00000-wbgrp-crawl067.us.archive.org-6682.warc.gz
ARCHIVEIT-3552-DAILY-ZBAVFR-20130212185957-00000-wbgrp-crawl064.us.archive.org-6680.warc.gz
```