### PR TITLE
Catch requests exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 sudo: false
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 install:
   - pip install -r requirements-test.txt
   - pip install flake8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,2 @@
 requests>=2.18.1
-pytest>=5.0.0
+pytest>=4.6.4

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,2 @@
 requests>=2.18.1
-pytest==3.2.1
+pytest>=5.0.0

--- a/tests/test_wasapi_client.py
+++ b/tests/test_wasapi_client.py
@@ -7,6 +7,7 @@ import multiprocessing
 import os
 import sys
 from collections import OrderedDict
+from logging import INFO
 from unittest.mock import call, mock_open, patch
 
 import pytest
@@ -331,13 +332,35 @@ class Test_download_file:
         with patch.object(session, 'get', return_value=mock_403) as mock_get, \
                 pytest.raises(wc.WASAPIDownloadError) as err:
             wc.download_file(self.data_file, session, self.filename)
-
         for item in (str(self.locations), self.filename):
-            assert item in str(err)
+            assert item in err.value.args[0]
         # Check all locations were tried.
         calls = [call(self.locations[0], stream=True),
                  call(self.locations[1], stream=True)]
         mock_get.assert_has_calls(calls)
+
+    def test_download_get_raises_some_RequestException(self, caplog):
+        caplog.set_level(INFO)
+        session = requests.Session()
+        mock_200 = MockResponse200('')
+
+        with patch.object(session, 'get') as mock_get, \
+                patch('wasapi_client.write_file') as mock_write_file:
+            # Raise a subclass of RequestException on first download attempt;
+            # mock a successful response on the second attempt
+            mock_get.side_effect = [requests.exceptions.ConnectionError(),
+                                    mock_200]
+            wc.download_file(self.data_file, session, self.filename)
+
+        # Check all locations were tried.
+        calls = [call(self.locations[0], stream=True),
+                 call(self.locations[1], stream=True)]
+        mock_get.assert_has_calls(calls)
+        mock_write_file.assert_called_once_with(mock_200, self.filename)
+        # Verify requests exception was caught and logged.
+        for msg in ('Error downloading http://loc1/blah.warc.gz:',
+                    'http://loc2/blah.warc.gz: 200 OK'):
+            assert msg in caplog.text
 
     def test_download_file_OSError(self):
         session = requests.Session()
@@ -350,7 +373,7 @@ class Test_download_file:
                 wc.download_file(self.data_file, session, self.filename)
 
         for item in (str(self.locations), self.filename):
-            assert item in str(err)
+            assert item in err.value.args[0]
         # Check we only tried downloading files until successful download.
         mock_get.assert_called_once_with(self.locations[0], stream=True)
         mock_write_file.assert_called_once_with(mock_200, self.filename)

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 max-line-length = 99
 
 [tox]
-envlist = py34,py35,py36,flake8
+envlist = py34,py35,py36,py37,flake8
 
 [testenv]
 usedevelop=True

--- a/wasapi_client.py
+++ b/wasapi_client.py
@@ -97,7 +97,7 @@ def get_webdata(webdata_uri, session):
     try:
         return response.json()
     except (JSONDecodeError, ValueError) as err:
-        sys.exit('Non-JSON response from {}'.format(webdata_uri))
+        sys.exit('Non-JSON response from {}:\n{}'.format(webdata_uri, err))
 
 
 def get_files_count(webdata_uri, auth=None):
@@ -216,7 +216,13 @@ def download_file(data_file, session, output_path):
         data_file.verified = True
         return data_file
     for location in data_file.locations:
-        response = session.get(location, stream=True)
+        try:
+            response = session.get(location, stream=True)
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as err:
+            # This could be a remote disconnect, read timeout, connection timeout,
+            # temporary name resolution issue...
+            LOGGER.error('Error downloading {}:\n{}'.format(location, err))
+            continue
         msg = '{}: {} {}'.format(location,
                                  response.status_code,
                                  response.reason)

--- a/wasapi_client.py
+++ b/wasapi_client.py
@@ -218,7 +218,7 @@ def download_file(data_file, session, output_path):
     for location in data_file.locations:
         try:
             response = session.get(location, stream=True)
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as err:
+        except requests.exceptions.RequestException as err:
             # This could be a remote disconnect, read timeout, connection timeout,
             # temporary name resolution issue...
             LOGGER.error('Error downloading {}:\n{}'.format(location, err))


### PR DESCRIPTION
@somexpert @madhulika95b This is a small PR to resolve #28 , so the client doesn't hang from an unhandled exception when trying to download a WARC file. When the get request causes an exception, the error will be logged, and the process will move on. If that file can't be downloaded from an alternate location, it is reported as a failure at the commandline at the end of the client's run.