### PR TITLE
Support for S3 download urls: presigned urls, S3 etag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+1.1.0
+------
+
+* Add support for Webrecorder.io. [#34](https://github.com/unt-libraries/py-wasapi-client/pull/34)
+
+1.0.0
+------
+
+* Initial release.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # py-wasapi-client [![Build Status](https://travis-ci.org/unt-libraries/py-wasapi-client.svg)](https://travis-ci.org/unt-libraries/py-wasapi-client)
-A client for the [Archive-It] WASAPI Data Transfer API. This client
-is being developed according to the [ait-specification](https://github.com/WASAPI-Community/data-transfer-apis/tree/master/ait-specification).
+A client for the WASAPI Data Transfer API. Initially developed according to the
+[Archive-It specification](https://github.com/WASAPI-Community/data-transfer-apis/tree/master/ait-specification), the client now additionally supports [Webrecorder.io](https://webrecorder.io/).
 
 ## Requirements
 
@@ -96,8 +96,8 @@ query parameters:
 
 ## Configuration
 
-When you are using the tool to query an Archive-It WASAPI endpoint,
-you will need to supply a username and password for the API. You have
+When you are using the tool to query an Archive-It or Webrecorder WASAPI
+endpoint, you will need to supply a username and password for the API. You have
 three options to provide these credentials.
 
 1. Supply a username with `-u`, and you will be prompted for a password.
@@ -194,6 +194,13 @@ wasapi-client do the downloading, use the --urls flag.
 
 ```
 $ wasapi-client --profile unt --crawl 256119 --urls
+```
+
+To use the client with Webrecorder (not all query parameters may be supported),
+supply the base URL with -b.
+
+```
+$ wasapi-client -b https://webrecorder.io/api/v1/download/webdata --profile webrecorder --collection my_collection -d warcs
 ```
 
 ## Run the Tests

--- a/wasapi_client.py
+++ b/wasapi_client.py
@@ -32,6 +32,7 @@ PROFILE_PATH = os.path.join(os.path.expanduser('~'), '.wasapi-client')
 
 PRE_SIGNED_REGEX = [re.compile(r'https://.*\.s3.amazonaws\.com/.*[?].*Signature=.+')]
 
+
 def start_listener_logging(log_q, path=''):
     formatter = logging.Formatter('%(asctime)s %(levelname)s %(name)s %(message)s')
     if path:
@@ -313,9 +314,12 @@ def verify_file(checksums, file_path):
     return False
 
 
-# implements double-md5 computation as suggested in
-# https://zihao.me/post/calculating-etag-for-aws-s3-objects/
 class S3DoubleMD5:
+    """Implements double-md5 computation as suggested by:
+
+    https://zihao.me/post/calculating-etag-for-aws-s3-objects/
+    """
+
     def __init__(self):
         self.md5s = []
 
@@ -329,7 +333,6 @@ class S3DoubleMD5:
         digests = b''.join(m.digest() for m in self.md5s)
         digests_md5 = hashlib.md5(digests)
         return '{}-{}'.format(digests_md5.hexdigest(), len(self.md5s))
-
 
 
 def calculate_sum(hash_function, file_path, read_limit=READ_LIMIT):

--- a/wasapi_client.py
+++ b/wasapi_client.py
@@ -284,12 +284,12 @@ def verify_file(checksums, file_path):
     for algorithm, value in checksums.items():
         read_limit = READ_LIMIT
         hash_function = getattr(hashlib, algorithm, None)
-        if not hash_function and algorithm == 'etag':
+        if not hash_function and algorithm == 's3etag':
             # if etag does not contain a '-', then its just a regular md5
             if '-' not in value:
                 hash_function = hashlib.md5
 
-            # otherwise, its likely 'double-md5'
+            # otherwise, its likely a 'double-md5'
             # see: https://zihao.me/post/calculating-etag-for-aws-s3-objects/
             else:
                 hash_function = S3DoubleMD5


### PR DESCRIPTION
This PR adds support for WASAPI download urls that are Amazon S3 urls, and will make the client work correctly with the Webrecorder WASAPI implementation.

It includes two parts:
- Allow skipping the auth header if a url matches a certain pattern, so far just the Amazon S3 pre-signed urls (containing a signature). The pre-signed urls can be used directly to download WARCs for a limited amount of time and due to require additional auth (and will be rejected if there is an auth header):
https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-presigned-urls.html

- Treat the special `etag` hash algorithm as either an md5 or a double-md5.
If it encounters `etag`, it checks to see if the checksum has a `-`, if not, its a regular md5
Otherwise, compute the 'double-md5' as suggested: https://zihao.me/post/calculating-etag-for-aws-s3-objects/