### PR TITLE
Avoid qsize for mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,20 @@ jobs:
   include:
     - os: linux
       dist: xenial
+      python: 3.4
+    - os: linux
+      dist: xenial
+      python: 3.5
+    - os: linux
+      dist: xenial
+      python: 3.6
+    - os: linux
+      dist: xenial
+      python: 3.7
     - os: osx
+      python: 3.7
 language: python
 sudo: false
-python:
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
 install:
   - pip install -r requirements-test.txt
   - pip install flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
       dist: xenial
       python: 3.7
     - os: osx
-      python: 3.7
+      python: 3.6
 language: python
 sudo: false
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,14 @@ jobs:
       dist: xenial
       python: 3.7
     - os: osx
-      python: 3.6
+      osx_image: xcode11
+      language: shell
 language: python
 sudo: false
 install:
-  - pip install -r requirements-test.txt
-  - pip install flake8
-  - python setup.py install
+  - pip3 install -r requirements-test.txt
+  - pip3 install flake8
+  - python3 setup.py install
 script:
     - pytest
     - flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
-dist: xenial
+jobs:
+  include:
+    - os: linux
+      dist: xenial
+    - os: osx
 language: python
 sudo: false
 python:

--- a/tests/test_wasapi_client.py
+++ b/tests/test_wasapi_client.py
@@ -6,6 +6,7 @@ import json
 import multiprocessing
 import os
 import sys
+import time
 from collections import OrderedDict
 from logging import INFO
 from unittest.mock import call, mock_open, patch
@@ -149,13 +150,17 @@ class Test_Downloads:
         mock_session.return_value.get.return_value = MockResponse200()
         downloads = wc.Downloads(WASAPI_URL, download=True)
         j_queue = downloads.get_q
-        assert j_queue.qsize() == 2
+        # queue needs a moment before consumption.
+        time.sleep(.15)
+
         # Drain the JoinableQueue to avoid BrokenPipeError.
         # There could be a better way to handle this...
-        while j_queue.qsize():
+        for _ in (1, 2):
             q_item = j_queue.get()
             assert isinstance(q_item, wc.DataFile)
             j_queue.task_done()
+        # Verify it was two items on the queue.
+        assert j_queue.empty()
 
     def test_populate_downloads_multi_page(self, mock_session):
         """Test the queue returned for multiple results pages."""
@@ -165,12 +170,16 @@ class Test_Downloads:
         mock_session.return_value.get.side_effect = responses
         downloads = wc.Downloads(WASAPI_URL, download=True)
         j_queue = downloads.get_q
-        assert j_queue.qsize() == 4
+        # queue needs a moment before consumption.
+        time.sleep(.25)
+
         # Drain the JoinableQueue to avoid BrokenPipeError.
-        while j_queue.qsize():
+        for _ in range(4):
             q_item = j_queue.get()
             assert isinstance(q_item, wc.DataFile)
             j_queue.task_done()
+        # Verify there were only 4 items on the queue.
+        assert j_queue.empty()
 
     def test_populate_downloads_no_get_q(self, mock_session):
         """Test download=False prevents get_q attribute existing."""
@@ -608,15 +617,18 @@ class TestDownloader:
             p.run()
         # If the join doesn't block, the queue is fully processed.
         get_q.join()
-        assert result_q.qsize() == 2
-        assert log_q.qsize() == 0
+        # Verify there is nothing on the log_q.
+        assert log_q.empty()
         for _ in (1, 2):
             assert result_q.get() == ('success', self.filename)
+        # Verify those were the only two results on the result_q.
+        assert result_q.empty()
 
     @patch('wasapi_client.download_file')
     def test_run_WASAPIDownloadError(self, mock_download):
         """Test downloader when downloads fail."""
-        mock_download.side_effect = wc.WASAPIDownloadError()
+        expected_error = 'WD Error'
+        mock_download.side_effect = wc.WASAPIDownloadError(expected_error)
         # Create a queue holding two sets of file data.
         get_q = multiprocessing.JoinableQueue()
         for _ in (1, 2):
@@ -628,10 +640,12 @@ class TestDownloader:
         p.run()
         # If the join doesn't block, the queue is fully processed.
         get_q.join()
-        assert result_q.qsize() == 2
-        assert log_q.qsize() == 2
         for _ in (1, 2):
+            assert log_q.get().msg == expected_error
             assert result_q.get() == ('failure', self.filename)
+        # Verify those were the only two results on the result_q.
+        time.sleep(.25)
+        assert result_q.empty()
 
     def test_run_file_already_verified(self):
         """Test a downloaded file is not verified twice."""
@@ -650,10 +664,10 @@ class TestDownloader:
             p.run()
         # If the join doesn't block, the queue is fully processed.
         get_q.join()
-        assert result_q.qsize() == 2
-        assert log_q.qsize() == 0
+        assert log_q.empty()
         for _ in (1, 2):
             assert result_q.get() == ('success', self.filename)
+        assert result_q.empty()
         # Check verify_exists was not called, since it was called in `download_file`.
         assert not mock_verify.called
 

--- a/tests/test_wasapi_client.py
+++ b/tests/test_wasapi_client.py
@@ -641,7 +641,7 @@ class TestDownloader:
             assert result_q.get() == ('failure', self.filename)
         # Verify those were the only two results on the result_q.
         # Sometimes `empty` needs a moment to register.
-        time.sleep(.25)
+        time.sleep(.5)
         assert result_q.empty()
 
     def test_run_file_already_verified(self):

--- a/tests/test_wasapi_client.py
+++ b/tests/test_wasapi_client.py
@@ -6,7 +6,6 @@ import json
 import multiprocessing
 import os
 import sys
-import time
 from collections import OrderedDict
 from logging import INFO
 from unittest.mock import call, mock_open, patch
@@ -604,8 +603,9 @@ class TestDownloader:
         get_q = multiprocessing.JoinableQueue()
         for _ in (1, 2):
             get_q.put(self.data_file)
-        result_q = multiprocessing.Queue()
-        log_q = multiprocessing.Queue()
+        manager = multiprocessing.Manager()
+        result_q = manager.Queue()
+        log_q = manager.Queue()
         with patch('wasapi_client.verify_file', return_value=True), \
                 patch('wasapi_client.download_file', return_value=self.data_file):
             p = wc.Downloader(get_q, result_q, log_q)
@@ -629,8 +629,9 @@ class TestDownloader:
         get_q = multiprocessing.JoinableQueue()
         for _ in (1, 2):
             get_q.put(self.data_file)
-        result_q = multiprocessing.Queue()
-        log_q = multiprocessing.Queue()
+        manager = multiprocessing.Manager()
+        result_q = manager.Queue()
+        log_q = manager.Queue()
         p = wc.Downloader(get_q, result_q, log_q)
         p.start()
         p.run()
@@ -641,7 +642,6 @@ class TestDownloader:
             assert result_q.get() == ('failure', self.filename)
         # Verify those were the only two results on the result_q.
         # Sometimes `empty` needs a moment to register.
-        time.sleep(.5)
         assert result_q.empty()
 
     def test_run_file_already_verified(self):
@@ -652,8 +652,9 @@ class TestDownloader:
         get_q = multiprocessing.JoinableQueue()
         for _ in (1, 2):
             get_q.put(self.data_file)
-        result_q = multiprocessing.Queue()
-        log_q = multiprocessing.Queue()
+        manager = multiprocessing.Manager()
+        result_q = manager.Queue()
+        log_q = manager.Queue()
         with patch('wasapi_client.verify_file', return_value=True) as mock_verify, \
                 patch('wasapi_client.download_file', return_value=return_data_file):
             p = wc.Downloader(get_q, result_q, log_q)

--- a/tests/test_wasapi_client.py
+++ b/tests/test_wasapi_client.py
@@ -150,8 +150,6 @@ class Test_Downloads:
         mock_session.return_value.get.return_value = MockResponse200()
         downloads = wc.Downloads(WASAPI_URL, download=True)
         j_queue = downloads.get_q
-        # queue needs a moment before consumption.
-        time.sleep(.15)
 
         # Drain the JoinableQueue to avoid BrokenPipeError.
         # There could be a better way to handle this...
@@ -170,8 +168,6 @@ class Test_Downloads:
         mock_session.return_value.get.side_effect = responses
         downloads = wc.Downloads(WASAPI_URL, download=True)
         j_queue = downloads.get_q
-        # queue needs a moment before consumption.
-        time.sleep(.25)
 
         # Drain the JoinableQueue to avoid BrokenPipeError.
         for _ in range(4):
@@ -644,6 +640,7 @@ class TestDownloader:
             assert log_q.get().msg == expected_error
             assert result_q.get() == ('failure', self.filename)
         # Verify those were the only two results on the result_q.
+        # Sometimes `empty` needs a moment to register.
         time.sleep(.25)
         assert result_q.empty()
 


### PR DESCRIPTION
This modifies some tests to avoid using `qsize` which "[may raise `NotImplementedError` on Unix platforms like Mac OS X where sem_getvalue() is not implemented.](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Queue.qsize)" .

This should fix #35 . ping @madhulika95b @somexpert 

I have run these tests on a Mac.